### PR TITLE
Add install PKGBUILD feature

### DIFF
--- a/src/pipman/pip2pkgbuild.py
+++ b/src/pipman/pip2pkgbuild.py
@@ -86,6 +86,24 @@ class Pip2Pkgbuild():
             with open(os.path.join(pack['dir'], 'PKGBUILD'), 'w') as f:
                 f.write(pkgbuild)
 
+    def install_all(self, prefix='.'):
+        """Install the packages"""
+        self.generate_all(prefix)
+        for _, dep in self.dependencies.items():
+            path = os.getcwd()
+            os.chdir(os.path.join(prefix, dep['pkgname']))
+            subprocess.check_call(['makepkg',
+                                   '--install',
+                                   '--asdeps'])
+            os.chdir(path)
+        for _, pack in self.packages.items():
+            path = os.getcwd()
+            os.chdir(os.path.join(prefix, pack['pkgname']))
+            subprocess.check_call(['makepkg',
+                                   '--install',
+                                   os.path.join(prefix, pack['pkgname'])])
+            os.chdir(path)
+
     def install_in_venv(self, package):
         """Install package in virtualenv"""
         Pip2Pkgbuild.log.info("Installing '%s' in virutalenv" % package)

--- a/src/pipman/pip2pkgbuild.py
+++ b/src/pipman/pip2pkgbuild.py
@@ -18,6 +18,7 @@ class Pip2Pkgbuild():
 
         # intialize packages variable
         self.packages = {}
+        self.dependencies = {}
 
         # install and create package dict
         for pack in packages:
@@ -53,7 +54,17 @@ class Pip2Pkgbuild():
             dir = os.path.join(prefix, pack['pkgname'])
             if os.path.exists(dir):
                 Pip2Pkgbuild.log.error("Directory '%s' already exists" % dir)
-                quit()
+                return
+
+            # store directory in package dict
+            self.packages[pack['pack']]['dir'] = dir
+
+        for pack in self.dependencies:
+            pack = self.dependencies[pack]
+            dir = os.path.join(prefix, pack['pkgname'])
+            if os.path.exists(dir):
+                Pip2Pkgbuild.log.error("Directory '%s' already exists" % dir)
+                return
 
             # store directory in package dict
             self.packages[pack['pack']]['dir'] = dir
@@ -61,6 +72,14 @@ class Pip2Pkgbuild():
         # generate the package build and store in package/PKGBUILD
         for pack in self.packages:
             pack = self.packages[pack]
+            pkgbuild = Pip2Pkgbuild._generate_pkgbuild(pack)
+            os.makedirs(pack['dir'])
+
+            with open(os.path.join(pack['dir'], 'PKGBUILD'), 'w') as f:
+                f.write(pkgbuild)
+
+        for pack in self.dependencies:
+            pack = self.dependencies[pack]
             pkgbuild = Pip2Pkgbuild._generate_pkgbuild(pack)
             os.makedirs(pack['dir'])
 
@@ -86,8 +105,8 @@ class Pip2Pkgbuild():
 
             # add dependencies to self.packages, if not there yet
             for dep in dependencies:
-                if dep and dep not in self.packages.keys():
-                    self.packages[dep] = Pip2Pkgbuild.compile_package_info(dep)
+                if dep and dep not in self.dependencies.keys():
+                    self.dependencies[dep] = Pip2Pkgbuild.compile_package_info(dep)
 
         except AttributeError:
             dependencies = None

--- a/src/pipman/pipman.py
+++ b/src/pipman/pipman.py
@@ -11,11 +11,13 @@ Examples:
     pipman sympy
     pipman numpy sympy --target-dir=/tmp
     pipman -s browser
+    pipman -i browser
 
 Options:
     -h --help                      Show this screen.
     -t <dir>, --target-dir <dir>   Target dir [default: .].
     -s                             Search for packages in pip's repository
+    -i                             Generate PKGBUILDs and call makepkg to install them
 
 Positional:
     packages                       Packages to be generated
@@ -36,6 +38,17 @@ def generate(args):
     Pip2Pkgbuild(packages).generate_all(dir)
 
 
+def install(args):
+    from pip2pkgbuild import Pip2Pkgbuild
+    dir = args['--target-dir']
+    if dir is False:
+        dir = '.'
+
+    packages = args['<packages>']
+
+    Pip2Pkgbuild(packages).install_all(dir)
+
+
 def search(args):
     from search import search
     search(args['<packages>'])
@@ -48,5 +61,8 @@ if __name__ == '__main__':
 
     if args['-s']:
         action = search
+
+    if args['-i']:
+        action = install
 
     action(args)


### PR DESCRIPTION
add ``-i`` option for installing PKGBUILD (using ``makepkg``).
Main changes:
- add a ``dependencies`` variable in ``Pip2pkgbuild`` class to install dependencies (``--asdesps`` option) as dependencies with ``makepkg``
- add ``install_all`` method (which call ``makepkg`` on every packages/dependencies).
- add ``-i`` option which call ``install_all``
- replace ``quit()`` by ``return`` in ``generate_all`` (make ``generate_all`` not quit everything if the PKGBUILD already exists when installing the package).

For now, by default, when installing the package, the PKGBUILD is generated in ``.``. IMHO the default should be ``/tmp/pipman`` (or an other directory in ``/tmp``).