### PR TITLE
Do not prepend always 'python-' when the package

### DIFF
--- a/src/pipman/pip2pkgbuild.py
+++ b/src/pipman/pip2pkgbuild.py
@@ -214,6 +214,8 @@ class Pip2Pkgbuild():
             info_dict[i[0]] = i[1]
 
         info_dict['pack'] = package
-        info_dict['pkgname'] = "python-%s" % package.lower()
+        info_dict['pkgname'] = package.lower()
+        if (len(info_dict['pkgname']) >= 7) and (info_dict['pkgname'][:7] != "python-"):
+            info_dict['pkgname'] = "python-%s" % info_dict['pkgname']
 
         return info_dict


### PR DESCRIPTION
Avoid the 'python-python-' package name pattern.
Avoid:
- strange package name (e.g. ``python-python-mdp2``)
- dependency issue, for example ``py3status-modules`` has an optional dependency on ``python-mpd2``, on pip the package is called ``python-mdp2``. When installed with ``pipman``, the package is called ``python-python-mpd2`` and is not listed in ``py3status-modules``'s dependencies.